### PR TITLE
Use 30bits for IR after instruction decode

### DIFF
--- a/submodules/PulseRain_MCU/PulseRain_processor_core/source/PulseRain_RV2T_core.v
+++ b/submodules/PulseRain_MCU/PulseRain_processor_core/source/PulseRain_RV2T_core.v
@@ -112,7 +112,7 @@ module PulseRain_RV2T_core (
         wire  [`REG_ADDR_BITS - 1 : 0]                  rs1;
         wire  [`REG_ADDR_BITS - 1 : 0]                  rs2;
         
-        wire  [`XLEN - 1 : 0]                           decode_IR_out ;
+        wire  [`XLEN - 1 : 2]                           decode_IR_out ;
         wire  [`PC_BITWIDTH - 1 : 0]                    decode_PC_out ;
         
         wire  [`CSR_BITS - 1 : 0]                       decode_csr;
@@ -172,7 +172,7 @@ module PulseRain_RV2T_core (
         wire                                            exe_reg_ctl_CSR_write;
         wire [`CSR_BITS - 1 : 0]                        exe_csr_addr;
         
-        wire  [`XLEN - 1 : 0]                           exe_IR_out;
+        wire  [`XLEN - 1 : 2]                           exe_IR_out;
         wire  [`PC_BITWIDTH - 1 : 0]                    exe_PC_out;
         
         wire                                            data_access_mem_re;
@@ -619,7 +619,7 @@ module PulseRain_RV2T_core (
 // DEBUG
 //----------------------------------------------------------------------------
     assign peek_pc = exe_PC_out;
-    assign peek_ir = exe_IR_out;
+    assign peek_ir = { exe_IR_out, 2'b1 };
         
 endmodule
 

--- a/submodules/PulseRain_MCU/PulseRain_processor_core/source/RV2T_execution_unit.v
+++ b/submodules/PulseRain_MCU/PulseRain_processor_core/source/RV2T_execution_unit.v
@@ -40,7 +40,7 @@ module RV2T_execution_unit (
      // interface for the instruction decode
      //=====================================================================
         input wire                                              enable_in,
-        input wire [`XLEN - 1 : 0]                              IR_in,
+        input wire [`XLEN - 1 : 2]                              IR_in,
         input wire [`PC_BITWIDTH - 1 : 0]                       PC_in,
         input wire [`CSR_BITS - 1 : 0]                          csr_addr_in,
         
@@ -82,7 +82,7 @@ module RV2T_execution_unit (
         output reg                                              enable_out,
         output reg [`REG_ADDR_BITS - 1 : 0]                     rd_addr_out,
 
-        output reg [`XLEN - 1 : 0]                              IR_out,
+        output reg [`XLEN - 1 : 2]                              IR_out,
         output reg [`PC_BITWIDTH - 1 : 0]                       PC_out,
         
         output wire                                             branch_active,

--- a/submodules/PulseRain_MCU/PulseRain_processor_core/source/RV2T_instruction_decode.v
+++ b/submodules/PulseRain_MCU/PulseRain_processor_core/source/RV2T_instruction_decode.v
@@ -58,7 +58,7 @@ module RV2T_instruction_decode (
      // interface for next stage
      //=====================================================================
 
-        output reg [`XLEN - 1 : 0]                              IR_out,
+        output reg [`XLEN - 1 : 2]                              IR_out,
         output reg [`PC_BITWIDTH - 1 : 0]                       PC_out,
         
         output reg                                              ctl_load_X_from_rs1,
@@ -140,7 +140,7 @@ module RV2T_instruction_decode (
                     IR_out <= 0;
                     PC_out <= 0;
                 end else begin
-                    IR_out <= IR_in;
+                    IR_out <= IR_in[`XLEN - 1 : 2];
                     PC_out <= PC_in;
                 end
             end


### PR DESCRIPTION
Based on the specification, we only need most significant 30bits to execute.