### PR TITLE
Add iverilog simulator

### DIFF
--- a/sim/iverilog/Makefile
+++ b/sim/iverilog/Makefile
@@ -1,0 +1,177 @@
+###############################################################################
+# Copyright (c) 2018, PulseRain Technology LLC 
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+###############################################################################
+
+###############################################################################
+#== compliance test vector folder
+###############################################################################
+
+elf_folder = ../compliance
+ref_folder = ../compliance/references
+
+###############################################################################
+#== Put all the source files here
+###############################################################################
+
+src_base = ../../submodules/PulseRain_MCU/source
+src_sub = \
+../PulseRain_processor_core/source/mul_div/absolute_value \
+../PulseRain_processor_core/source/mul_div/long_slow_div_denom_reg \
+../PulseRain_processor_core/source/mul_div/mul_div_32 \
+../memory/microsemi/dual_port_ram \
+../memory/microsemi/single_port_ram_8bit \
+../memory/microsemi/single_port_ram \
+../PulseRain_processor_core/source/PulseRain_RV2T_core \
+../PulseRain_processor_core/source/RV2T_controller \
+../PulseRain_processor_core/source/RV2T_CSR \
+../PulseRain_processor_core/source/RV2T_data_access \
+../PulseRain_processor_core/source/RV2T_execution_unit \
+../PulseRain_processor_core/source/RV2T_fetch_instruction \
+../PulseRain_processor_core/source/RV2T_instruction_decode \
+../PulseRain_processor_core/source/RV2T_machine_timer \
+../PulseRain_processor_core/source/RV2T_memory \
+../PulseRain_processor_core/source/RV2T_mm_reg \
+../PulseRain_processor_core/source/RV2T_reg_file \
+../peripherals/UART/UART_TX
+
+src_top = PulseRain_RV2T_MCU
+testbench = mcu_tb.v
+
+src_sub_v = $(patsubst %, $(src_base)/%.v,$(src_sub))
+src_top_v = $(src_top).v
+testbench_cpp = $(testbench).cpp
+
+ 
+target = PulseRain_RV2T_MCU
+
+###############################################################################
+# All test cases
+###############################################################################
+all_test_cases =  \
+I-ADD-01 \
+I-ADDI-01 \
+I-AND-01 \
+I-ANDI-01 \
+I-AUIPC-01 \
+I-BEQ-01 \
+I-BGE-01 \
+I-BGEU-01 \
+I-BLT-01 \
+I-BLTU-01 \
+I-BNE-01 \
+I-CSRRC-01 \
+I-CSRRCI-01 \
+I-CSRRS-01 \
+I-CSRRSI-01 \
+I-CSRRW-01 \
+I-CSRRWI-01 \
+I-DELAY_SLOTS-01 \
+I-EBREAK-01 \
+I-ECALL-01 \
+I-ENDIANESS-01 \
+I-FENCE.I-01 \
+I-IO \
+I-JAL-01 \
+I-JALR-01 \
+I-LB-01 \
+I-LBU-01 \
+I-LH-01 \
+I-LHU-01 \
+I-LUI-01 \
+I-LW-01 \
+I-MISALIGN_JMP-01 \
+I-MISALIGN_LDST-01 \
+I-NOP-01 \
+I-OR-01 \
+I-ORI-01 \
+I-RF_size-01 \
+I-RF_width-01 \
+I-RF_x0-01 \
+I-SB-01 \
+I-SH-01 \
+I-SLL-01 \
+I-SLLI-01 \
+I-SLT-01 \
+I-SLTI-01 \
+I-SLTIU-01 \
+I-SLTU-01 \
+I-SRA-01 \
+I-SRAI-01 \
+I-SRL-01 \
+I-SRLI-01 \
+I-SUB-01 \
+I-SW-01 \
+I-XOR-01 \
+I-XORI-01
+
+
+
+
+test_run_case = $(filter-out $@, $(MAKECMDGOALS))
+
+count_test_run_case = $(words $(test_run_case))
+count_test_all = $(words $(all_test_cases))
+
+build : $(target)
+
+test : build
+	@echo "====> Testing $(target)"    
+	@echo "TEST CASE: $(test_run_case)"
+	@for t in $(test_run_case) ; do \
+		elf_file=$(elf_folder)/$$t.elf ;\
+		ref_file=$(ref_folder)/$$t.reference_output ;\
+		echo "testing $$elf_file  -r $$ref_file" ; \
+		./obj_dir/V$(src_top) $$elf_file  -r $$ref_file || exit ; \
+		sleep 1 ; \
+	done
+	@echo "====> Test PASSED, Total of $(count_test_run_case) case(s)"     
+
+test_all : build
+	@echo "====> Testing ALL"    
+	@for t in $(all_test_cases) ; do \
+		echo "TEST CASE: $$t" ; \
+		elf_file=$(elf_folder)/$$t.elf ;\
+		ref_file=$(ref_folder)/$$t.reference_output ;\
+		echo "testing $$elf_file  -r $$ref_file" ; \
+		./obj_dir/V$(src_top) $$elf_file  -r $$ref_file || exit ; \
+		sleep 1 ; \
+	done
+	@echo "====> Test PASSED, Total of $(count_test_all) cases \n"    
+    
+run : build
+	@echo "runing $(test_run_case)" ;
+	./obj_dir/V$(src_top) $(test_run_case)
+
+$(target) : $(src_sub_v) $(src_base)/$(src_top_v) $(testbench)
+	@echo "====> Building $(target)"
+	iverilog -o $(target) -I../../submodules/PulseRain_MCU/memory/microsemi -I../../submodules/PulseRain_MCU/common -I../../submodules/PulseRain_MCU/common/Microsemi/SmartFusion2 -I../../submodules/PulseRain_MCU/PulseRain_processor_core/source  -I../../submodules/PulseRain_MCU/PulseRain_processor_core/source/mul_div $(src_sub_v) $(src_base)/$(src_top_v) $(testbench)
+
+clean :
+	@echo "====> Remove obj_dir"
+	-@rm -rf ./obj_dir
+
+help :
+	@echo "*) To build : make or make build\n"
+	@echo "*) To clean the build : make clean\n"
+	@echo "*) To test single or multiple compliance cases : make test case1 case2 case3 ..."
+	@echo "         for example : make test I-ADD-01 DIV I-FENCE.I-01"
+	@echo "*) To test all compliance cases : make test_all\n"
+	@echo "*) To run an elf file : make run file_name\n"
+    
+%:
+	@true
+    
+.PHONY: clean test test_all help run build

--- a/sim/iverilog/mcu_tb.v
+++ b/sim/iverilog/mcu_tb.v
@@ -1,0 +1,246 @@
+`timescale 1ns / 100ps
+
+`include "RV2T_common.vh"
+
+
+module mcu_test();
+
+    //=====================================================================
+    // clock and reset
+    //=====================================================================
+        reg                                            clk;                          
+        reg                                            reset_n;                      
+        reg                                            sync_reset;
+
+    
+    //=====================================================================
+    // Interface Onchip Debugger
+    //=====================================================================
+      //==  input   wire                                            run1_pause0;
+
+        reg                                            ocd_read_enable;
+        reg                                            ocd_write_enable;
+        
+        reg  [`MEM_ADDR_BITS - 1 : 0]                  ocd_rw_addr;
+        reg  [`XLEN - 1 : 0]                           ocd_write_word;
+        
+        wire                                            ocd_mem_enable_out;
+        wire  [`XLEN - 1 : 0]                           ocd_mem_word_out;        
+        
+        reg  [`REG_ADDR_BITS - 1 : 0]                  ocd_reg_read_addr;
+        reg                                             ocd_reg_we;
+        reg  [`REG_ADDR_BITS - 1 : 0]                  ocd_reg_write_addr;
+        reg  [`XLEN - 1 : 0]                           ocd_reg_write_data;
+
+    //=====================================================================
+    // UART
+    //=====================================================================
+        wire                                            TXD;
+        
+    //=====================================================================
+    // Interface for init/start
+    //=====================================================================
+        reg                                             start;
+        reg  [`PC_BITWIDTH - 1 : 0]                    start_address;
+        
+        wire                                            processor_paused;
+
+        wire  [`XLEN - 1 : 0]                           peek_pc;
+        wire  [`XLEN - 1 : 0]                           peek_ir;
+        
+        wire  [`XLEN_BYTES - 1 : 0]                     peek_mem_write_en;
+        wire  [`XLEN - 1 : 0]                           peek_mem_write_data;
+        wire [`MEM_ADDR_BITS - 1 : 0]                   peek_mem_addr;
+
+
+	PulseRain_RV2T_MCU PulseRain_RV2T_MCU_i(
+		.clk (clk),
+		.reset_n (reset_n),
+		.sync_reset (sync_reset),
+		
+		.ocd_read_enable (ocd_read_enable),
+		.ocd_write_enable (ocd_write_enable),
+		
+		.ocd_rw_addr (ocd_rw_addr),
+		.ocd_write_word (ocd_write_word),
+		
+		.ocd_mem_enable_out (ocd_mem_enable_out),
+		.ocd_mem_word_out (ocd_mem_word_out),
+		
+		.ocd_reg_read_addr (ocd_reg_read_addr),
+		.ocd_reg_we (ocd_reg_we),
+		.ocd_reg_write_addr (ocd_reg_write_addr),
+        .ocd_reg_write_data (ocd_reg_write_data),
+
+
+		.TXD (TXD),
+		
+		
+		.start (start),
+		.start_address (start_address),
+		
+		.processor_paused (processor_paused),
+		
+		.peek_pc (peek_pc),
+		.peek_ir (peek_ir),
+		
+		.peek_mem_write_en (peek_mem_write_en),
+		.peek_mem_write_data (peek_mem_write_data),
+		.peek_mem_addr (peek_mem_addr)
+	);
+
+  initial begin
+    clk = 1'b0;
+    reset_n = 1'b0;
+    repeat(4) #10 clk = ~clk;
+    reset_n = 1'b1;
+    forever #10 clk = ~clk; // generate a clock
+  end
+
+integer File;
+integer r;
+integer i;
+integer addr;
+reg[31:0] elf_buf;
+reg[127:0] reference_buf [0:25];
+
+// elf file header
+reg[15:0] e_type;
+reg[15:0] e_machine;
+reg[31:0] e_entry;
+reg[31:0] e_phoff;
+reg[15:0] e_phentsize;
+reg[15:0] e_phnum;
+
+reg[31:0] p_type;
+reg[31:0] p_offset;
+reg[31:0] p_vaddr;
+reg[31:0] p_paddr;
+reg[31:0] p_filesz;
+
+function [15:0] swap_16(input [15:0] in);
+    swap_16 =  {in[7:0], in[15:8]};
+endfunction
+
+function [31:0] swap_32(input [31:0] in);
+    swap_32 =  {in[7:0], in[15:8], in[23:16], in[31:24]};
+endfunction
+
+
+
+initial begin
+		$dumpvars(0, PulseRain_RV2T_MCU_i);
+
+		// Reset the CPU
+		sync_reset = 0;
+		ocd_reg_we = 0;
+		ocd_reg_read_addr = 0;
+		ocd_reg_write_addr = 0;
+		ocd_reg_write_data = 0;
+		ocd_read_enable = 0;
+		ocd_write_enable = 0;
+		ocd_rw_addr = 0;
+		ocd_write_word = 0;
+		start = 0;
+		start_address = 32'h80000000;
+		
+		#10
+
+        // open the file
+        File = $fopen("../compliance/I-ADD-01.elf", "rb");
+        if (!File) begin
+            $display("Could not open \"result.dat\"");
+            $finish;
+        end
+
+        // check elf header
+        r = $fseek(File, 16, 0);
+        r = $fread(e_type, File); e_type = swap_16(e_type);
+        r = $fseek(File, 18, 0);
+        r = $fread(e_machine, File); e_machine = swap_16(e_type);
+        r = $fseek(File, 24, 0);
+        r = $fread(e_entry, File); e_entry = swap_32(e_entry);
+
+        r = $fseek(File, 28, 0);
+        r = $fread(e_phoff, File); e_phoff = swap_32(e_phoff);
+        r = $fseek(File, 42, 0);
+        r = $fread(e_phentsize, File); e_phentsize = swap_16(e_phentsize);
+        r = $fseek(File, 44, 0);
+        r = $fread(e_phnum, File); e_phnum = swap_16(e_phnum);
+
+        $display("type:0x%h, machine:0x%h, entry:0x%h", e_type, e_machine, e_entry);
+        $display("phoff: %h, phent: %h, phnum: %h", e_phoff, e_phentsize, e_phnum);
+
+        if (e_type != 2 || e_machine != 16'h0200) begin
+            $display("Not a RISC-V Executable");
+            $finish;
+        end
+
+        for (i = 0; i < e_phnum; i = i + 1) begin
+            r = $fseek(File, e_phoff + i * e_phentsize, 0);
+            r = $fread(p_type, File); p_type = swap_32(p_type);
+            r = $fread(p_offset, File); p_offset = swap_32(p_offset);
+            r = $fread(p_vaddr, File); p_vaddr = swap_32(p_vaddr);
+            r = $fread(p_paddr, File); p_paddr = swap_32(p_paddr);
+            r = $fread(p_filesz, File); p_filesz = swap_32(p_filesz);
+
+            $display("program header: %d: %h %h %h %h", i, p_type, p_offset, p_vaddr, p_filesz);
+            ocd_write_enable = 1;
+            r = $fseek(File, p_offset, 0);
+            for (addr = p_vaddr; addr < p_vaddr + p_filesz; addr = addr + 4) begin
+                r = $fread(elf_buf, File);
+                elf_buf = swap_32(elf_buf);
+
+                ocd_rw_addr = addr >> 2;
+                ocd_write_word = elf_buf;
+                @(posedge clk);
+                // $display("%h = %h", ocd_rw_addr * 4, ocd_write_word);
+            end
+            ocd_write_enable = 0;
+            @(posedge clk);
+        end
+        $fclose(File);
+
+        // start the CPU
+		start = 1;
+		repeat(1000) begin
+			$display("PC = %h IR = %h", peek_pc, peek_ir);
+			@(posedge clk);
+		end
+
+        // check the result
+        $readmemh("../compliance/references/I-ADD-01.reference_output", reference_buf);
+        for(i=0; i < 255 && ~(^reference_buf[i] === 1'bX); i = i + 1) begin
+            $display("%d: %h", i, reference_buf[i]);
+        end
+        
+        // display error/success
+        $finish;
+end
+
+
+endmodule
+
+
+/*
+
+function write_mem(
+    input integer lma,
+    input integer length,
+    input memblock);
+
+    integer addr;
+    integer data;
+
+    for (addr = lma; addr < lma + length; addr = addr + 4) begin
+        data = {memblock[offset + 3], memblock[offset + 2], memblock[offset + 1], memblock[offset]};
+        ocd_rw_addr = addr >> 2;
+        ocd_write_word = data;
+        ocd_write_enable = 1;
+        @(posedge clk);
+        ocd_write_enable = 0;
+        @(posedge clk);
+    end
+
+endfunction
+*/

--- a/submodules/PulseRain_MCU/memory/microsemi/single_port_ram.v
+++ b/submodules/PulseRain_MCU/memory/microsemi/single_port_ram.v
@@ -44,7 +44,7 @@ module single_port_ram #(parameter ADDR_WIDTH = 14, DATA_WIDTH = 16) (
     
     generate
         if (`MEM_SIZE_IN_BYTES == (48 * 1024)) begin: gen_if_proc
-            for (i = 0; i < (DATA_WIDTH / 8); i = i + 1) begin : gen_for_proc
+            for (i = 0; i < (DATA_WIDTH / 8); i = i + 1) begin : gen_for_proc1
                 
                  single_port_ram_8bit #(.ADDR_WIDTH (ADDR_WIDTH - 1)) ram_8bit_1st (
                     .addr (addr[ADDR_WIDTH - 2 : 0]),
@@ -54,7 +54,7 @@ module single_port_ram #(parameter ADDR_WIDTH = 14, DATA_WIDTH = 16) (
                     .dout (dout_1st [(i + 1) * 8 - 1 : i * 8]));
             end
             
-            for (i = 0; i < (DATA_WIDTH / 8); i = i + 1) begin : gen_for_proc
+            for (i = 0; i < (DATA_WIDTH / 8); i = i + 1) begin : gen_for_proc2
                 
                  single_port_ram_8bit #(.ADDR_WIDTH (ADDR_WIDTH - 2)) ram_8bit_2nd (
                     .addr (addr[ADDR_WIDTH - 3 : 0]),


### PR DESCRIPTION
The iverilog can be installed as:
apt-get install iverilog gtkwave

The iverilog supports collecting wave which helps the debug.

TODO:
1. Support passing elf file from command line, and support all test cases.
2. parse the [begin|end]_signature from elf file so that we can verify the result against with reference_output. For now, we can still use verilator to validate result. and use iverilog to debug/troubleshooting.
3. cleanup makefile