### PR TITLE
 Consolidate memory read/write regs into one access reg 

### DIFF
--- a/submodules/PulseRain_MCU/PulseRain_processor_core/source/PulseRain_RV2T_core.v
+++ b/submodules/PulseRain_MCU/PulseRain_processor_core/source/PulseRain_RV2T_core.v
@@ -67,7 +67,7 @@ module PulseRain_RV2T_core (
         output  wire  [31 : 0]                                  peek_ir,
         
         
-        output  wire  [`MEM_ADDR_BITS - 1 : 0]                  mem_addr,
+        output  wire [`MEM_ADDR_BITS - 1 : 0]                   mem_addr,
         output  wire [`XLEN_BYTES - 1 : 0]                      mem_write_en,
         output  wire [`XLEN - 1 : 0]                            mem_write_data,
         
@@ -163,9 +163,8 @@ module PulseRain_RV2T_core (
         wire                                            exe_load_active;
         wire                                            exe_store_active;
         wire [`XLEN - 1 : 0]                            exe_data_to_store;
-        wire [`XLEN - 1 : 0]                            exe_mem_write_addr;
-        wire [`XLEN - 1 : 0]                            exe_mem_read_addr;
-        wire                                            exe_unaligned_write;
+        wire [`XLEN - 1 : 0]                            exe_mem_access_addr;
+        wire                                            exe_mem_access_unaligned;
         wire                                            exe_unaligned_read;
         wire [2 : 0]                                    exe_width_load_store;
         wire                                            exe_reg_ctl_CSR;
@@ -476,10 +475,8 @@ module PulseRain_RV2T_core (
                 .store_active      (exe_store_active),
                 .width_load_store  (exe_width_load_store),
                 .data_to_store     (exe_data_to_store),
-                .mem_write_addr    (exe_mem_write_addr),
-                .mem_read_addr     (exe_mem_read_addr),
-                .unaligned_write   (exe_unaligned_write),
-                .unaligned_read    (exe_unaligned_read),
+                .mem_access_addr    (exe_mem_access_addr),
+                .mem_access_unaligned   (exe_mem_access_unaligned),
                 .reg_ctl_CSR       (exe_reg_ctl_CSR),
                 .reg_ctl_CSR_write (exe_reg_ctl_CSR_write),
                 .csr_addr_out      (exe_csr_addr),
@@ -516,10 +513,9 @@ module PulseRain_RV2T_core (
                 .store_active     (exe_store_active),
                 .width_load_store (exe_width_load_store),
                 .data_to_store    (exe_data_to_store),
-                .mem_write_addr   (exe_mem_write_addr),
-                .mem_read_addr    (exe_mem_read_addr),
-                .unaligned_write  (exe_unaligned_write),
-                .unaligned_read   (exe_unaligned_read),
+                .mem_access_addr  (exe_mem_access_addr),
+                .mem_access_unaligned  (exe_mem_access_unaligned),
+
                 .mul_div_done     (mul_div_done),
                 .ctl_reg_we (data_access_reg_we),
                 .ctl_reg_data_to_write (data_access_reg_data_to_write),
@@ -580,9 +576,8 @@ module PulseRain_RV2T_core (
                               
                 .load_active     (exe_load_active),
                 .data_to_store   (exe_data_to_store),
-                .mem_write_addr  (exe_mem_write_addr),
-                .mem_read_addr   (exe_mem_read_addr),
-                .unaligned_write (exe_unaligned_write),
+                .mem_access_addr  (exe_mem_access_addr),
+                .unaligned_write (exe_mem_access_unaligned),
 
                 .store_done (store_done),
                 .load_done  (load_done),

--- a/submodules/PulseRain_MCU/PulseRain_processor_core/source/RV2T_controller.v
+++ b/submodules/PulseRain_MCU/PulseRain_processor_core/source/RV2T_controller.v
@@ -73,8 +73,7 @@ module RV2T_controller (
         
         input wire                                          load_active,
         input wire [`XLEN - 1 : 0]                          data_to_store,
-        input wire [`XLEN - 1 : 0]                          mem_write_addr,
-        input wire [`XLEN - 1 : 0]                          mem_read_addr,
+        input wire [`XLEN - 1 : 0]                          mem_access_addr,
         input wire                                          unaligned_write,
         
         input wire                                          store_done,
@@ -144,7 +143,7 @@ module RV2T_controller (
             
             reg                                             first_exe;
 
-            reg [`XLEN - 1 : 0]                             mem_read_addr_d1;
+            reg [`XLEN - 1 : 0]                             mem_access_addr_d1;
             
             wire                                            exception_active;
             wire                                            exception_active_reg;    
@@ -194,7 +193,7 @@ module RV2T_controller (
                         exception_alignment_reg <= 0;
                         interrupt_active <= 0;
                         
-                        mem_read_addr_d1  <= 0;
+                        mem_access_addr_d1  <= 0;
             
                         ctl_set_interrupt_active_reg <= 0;
                         
@@ -208,7 +207,7 @@ module RV2T_controller (
                         
                         activate_exception <= ctl_activate_exception;
                         
-                        mem_read_addr_d1  <= mem_read_addr;
+                        mem_access_addr_d1  <= mem_access_addr;
             
                         
                         if (data_access_enable) begin
@@ -219,7 +218,7 @@ module RV2T_controller (
                             end
                             
                             if (exception_alignment) begin // store exception
-                                exception_addr <= mem_write_addr;
+                                exception_addr <= mem_access_addr;
                             end else begin
                                 case (1'b1) // synthesis parallel_case 
                                     branch_active : begin
@@ -233,7 +232,7 @@ module RV2T_controller (
                                 endcase
                             end
                         end else if (exception_alignment) begin // load exception
-                            exception_addr <= mem_read_addr_d1;
+                            exception_addr <= mem_access_addr_d1;
                         end 
                         
                                 

--- a/submodules/PulseRain_MCU/PulseRain_processor_core/source/RV2T_execution_unit.v
+++ b/submodules/PulseRain_MCU/PulseRain_processor_core/source/RV2T_execution_unit.v
@@ -658,8 +658,8 @@ module RV2T_execution_unit (
             
             assign data_to_store = Y;
 
-            assign mem_access_addr = ({32{store_active}} & (X + {{20{IR_out [31]}}, IR_out [31 : 25], IR_out [11 : 7]})) |
-                                     ({32{load_active}} & (X + {{20{IR_out[31]}}, IR_out[31 : 20]}));
+            assign mem_access_addr = ({32{ctl_STORE}} & (X + {{20{IR_out [31]}}, IR_out [31 : 25], IR_out [11 : 7]})) |
+                                     ({32{ctl_LOAD}} & (X + {{20{IR_out[31]}}, IR_out[31 : 20]}));
 
             assign mem_access_unaligned = (width == `WIDTH_32) ? (mem_access_addr[0] | mem_access_addr[1]) : ( (width == `WIDTH_16) || (width == `WIDTH_16U) ?  mem_access_addr[0] : 0 );
             assign width_load_store = width;


### PR DESCRIPTION
As riscv32 doesn't have instruction with read/write memory at the same time, we can combine the nodes for read/write to one set of nodes.