### PR TITLE
Fix illegal instruction handling

### DIFF
--- a/submodules/PulseRain_MCU/PulseRain_processor_core/source/PulseRain_RV2T_core.v
+++ b/submodules/PulseRain_MCU/PulseRain_processor_core/source/PulseRain_RV2T_core.v
@@ -191,11 +191,12 @@ module PulseRain_RV2T_core (
         wire [`XLEN - 1 : 0]                            csr_new_value;
         wire [`XLEN - 1 : 0]                            csr_old_value;
         
-        wire                                            csr_exception_illegal_instruction;
         wire                                            exception_ecall;
         wire                                            exception_ebreak;
         wire                                            exception_alignment;
-        wire                                            exception_illegal_instruction;
+
+        wire                                            decode_exception_illegal_instruction;
+        wire                                            csr_exception_illegal_instruction;
         
         wire                                            activate_exception;
         wire  [`EXCEPTION_CODE_BITS - 1 : 0]            exception_code;
@@ -419,7 +420,7 @@ module PulseRain_RV2T_core (
                 .ctl_MRET                        (decode_ctl_MRET),
                 .ctl_WFI                         (decode_ctl_WFI),
 
-                .exception_illegal_instruction   (exception_illegal_instruction));
+                .exception_illegal_instruction   (decode_exception_illegal_instruction));
                 
         //---------------------------------------------------------------------
         // execution unit
@@ -455,7 +456,7 @@ module PulseRain_RV2T_core (
                 
                 .rs1_in (reg_file_read_rs1_data_out),
                 .rs2_in (reg_file_read_rs2_data_out),
-     
+
                 .csr_in (csr_read_data_out),
          
                 .enable_out (),
@@ -606,7 +607,7 @@ module PulseRain_RV2T_core (
                 .activate_exception           (activate_exception),
                 .exception_PC                 (exception_PC),
                 .exception_addr               (exception_addr),
-                .exception_illegal_instruction (exception_illegal_instruction | csr_exception_illegal_instruction),
+                .exception_illegal_instruction (decode_exception_illegal_instruction | csr_exception_illegal_instruction),
                 .paused                       (paused)
                 
                 );
@@ -615,7 +616,7 @@ module PulseRain_RV2T_core (
 // DEBUG
 //----------------------------------------------------------------------------
     assign peek_pc = exe_PC_out;
-    assign peek_ir = { exe_IR_out, 2'b1 };
+    assign peek_ir = { exe_IR_out, 2'b11 };
         
 endmodule
 

--- a/submodules/PulseRain_MCU/PulseRain_processor_core/source/RV2T_fetch_instruction.v
+++ b/submodules/PulseRain_MCU/PulseRain_processor_core/source/RV2T_fetch_instruction.v
@@ -102,7 +102,7 @@ module RV2T_fetch_instruction (
                 always @(posedge clk, negedge reset_n) begin : PC_proc
                     if (!reset_n) begin
                         PC_out <= 0;
-                        IR_out <= 0;
+                        IR_out <= `RV32I_NOP;
                         fetch_enable_out <= 0;
                         PC_out_i <= 0;
                     end else begin

--- a/submodules/PulseRain_MCU/PulseRain_processor_core/source/RV2T_instruction_decode.v
+++ b/submodules/PulseRain_MCU/PulseRain_processor_core/source/RV2T_instruction_decode.v
@@ -94,6 +94,7 @@ module RV2T_instruction_decode (
         wire    [`REG_ADDR_BITS - 1 : 0]                        rd;
         wire    [2 : 0]                                         funct3;
         wire    [11 : 0]                                        funct12;
+        reg                                                     illegal;
         
     //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
     // data path
@@ -138,9 +139,15 @@ module RV2T_instruction_decode (
                 if (!reset_n) begin
                     IR_out <= 0;
                     PC_out <= 0;
+                    illegal <= 0;
                 end else begin
                     IR_out <= IR_in[`XLEN - 1 : 2];
                     PC_out <= PC_in;
+
+                    if (|IR_in == 1'b0 || &IR_in == 1'b1)
+                        illegal <= 1'b1;
+                    else
+                        illegal <= 1'b0;
                 end
             end
             
@@ -172,7 +179,8 @@ module RV2T_instruction_decode (
                 ctl_MISC_MEM = 0;
                 ctl_MRET = 0;
                 ctl_WFI = 0;
-                
+                exception_illegal_instruction = illegal;
+
                 case (IR_out [6 : 2]) // synthesis parallel_case 
                     `CMD_OP_IMM : begin
                         ctl_load_X_from_rs1 = 1'b1;


### PR DESCRIPTION
In IF stage, check all-zero or all-one cases and trigger illegal instruction trap. If decode failed, trigger as well. (not fully handled as there are many other cases).

Pass exception signal into the next EX stage and connect to Controller module to handle it.

Validated by illegal complains test.
