### PR TITLE
Support the different reference file

### DIFF
--- a/sim/verilator/tb_PulseRain_RV2T.cpp
+++ b/sim/verilator/tb_PulseRain_RV2T.cpp
@@ -467,11 +467,11 @@ void ref_file_process(std::string ref_file)
         } else {
             // std::cout << std::hex << "==> " << signature << "\n";
             
-            for (i = 0; i < 4; ++i) {
+            for (i = 0; i < signature.length() / 8; ++i) {
                 
                 data = 0;
                 for (j = 0; j < 8; ++j) {
-                    data += (std::stoul (signature.substr(31 - i * 8 - j, 1), nullptr, 16)) << (j*4);
+                    data += (std::stoul (signature.substr((signature.length() - 1) - i * 8 - j, 1), nullptr, 16)) << (j*4);
                 } // End of for loop j
                 
                 sig_list.push_back (data);


### PR DESCRIPTION
Some test suite like rv32imc or rv32ui contains a new format of reference file, which only 8 bytes on each line instead of 32. Make the reading code more general to handle it.